### PR TITLE
Bump requirements to support pytest 4.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bumpversion>=0.5.0
 needle>=0.5.0,<0.6.0
 Pillow>=4.1.0,<5.0.0
-pytest>=3.0.0,<4.0.0
+pytest>=3.0.0,<5.0.0
 pytest-cov>=2.5.0
 pytest-pep8>=1.0.0
 python-coveralls>=2.9.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='pytest-needle',
       url=u'https://github.com/jlane9/pytest-needle',
       packages=['pytest_needle'],
       entry_points={'pytest11': ['needle = pytest_needle.plugin', ]},
-      install_requires=['pytest>=3.0.0,<4.0.0', 'needle>=0.5.0,<0.6.0', 'pytest-selenium>=1.10.0,<2.0.0'],
+      install_requires=['pytest>=3.0.0,<5.0.0', 'needle>=0.5.0,<0.6.0', 'pytest-selenium>=1.10.0,<2.0.0'],
       keywords='py.test pytest needle imagemagick perceptualdiff pil selenium visual',
       license=__license__,
       classifiers=[


### PR DESCRIPTION
`pytest` has recently released a new major version, but `pytest-needle` prevents projects from upgrading to it only because it lists `pytest<4` in its dependencies. All tests pass just fine with `pytest` v4. I have also run a test suite in one of my projects using `pytest` v4 and `pytest-needle` and it behaved correctly, so I am quite confident `pytest-needle` is in fact compatible with `pytest` v4.